### PR TITLE
hide todo blocks

### DIFF
--- a/src/components/common/AppFooter.vue
+++ b/src/components/common/AppFooter.vue
@@ -171,12 +171,12 @@ import AppLogo from './AppLogo.vue';
 // Определение пунктов меню
 const navItems = [
   { name: 'Главная', path: '/' },
-  { name: 'Услуги', path: '/services' },
+  // { name: 'Услуги', path: '/services' },
   { name: 'Кейсы', path: '/cases' },
-  { name: 'Блог', path: '/blog' },
+  // { name: 'Блог', path: '/blog' },
   { name: 'О компании', path: '/about' },
   { name: 'Контакты', path: '/contacts' },
-  { name: 'Тарифы', path: '/pricing' },
+  // { name: 'Тарифы', path: '/pricing' },
 ];
 
 // Услуги

--- a/src/components/common/AppHeader.vue
+++ b/src/components/common/AppHeader.vue
@@ -112,12 +112,12 @@ const isMenuOpen = ref(false);
 // Определение пунктов меню
 const navItems = [
   { name: 'Главная', path: '/' },
-  { name: 'Услуги', path: '/services', isDisable: true },
+  // { name: 'Услуги', path: '/services', isDisable: true },
   { name: 'Кейсы', path: '/cases' },
-  { name: 'Блог', path: '/blog', isDisable: true },
+  // { name: 'Блог', path: '/blog', isDisable: true },
   { name: 'О компании', path: '/about' },
   { name: 'Контакты', path: '/contacts' },
-  { name: 'Тарифы', path: '/pricing', isDisable: true },
+  // { name: 'Тарифы', path: '/pricing', isDisable: true },
 ];
 
 // Проверка активного маршрута

--- a/src/components/home/CasesPreview.vue
+++ b/src/components/home/CasesPreview.vue
@@ -80,7 +80,7 @@
             </div>
 
             <!-- Кнопка "Подробнее" -->
-            <router-link
+            <!-- <router-link
               :to="`/cases/${caseItem.slug}`"
               class="inline-flex items-end text-primary-600 font-medium hover:text-primary-700 flex-1"
             >
@@ -97,7 +97,7 @@
                   clip-rule="evenodd"
                 />
               </svg>
-            </router-link>
+            </router-link> -->
           </div>
         </div>
       </div>

--- a/src/components/home/ServicesPreview.vue
+++ b/src/components/home/ServicesPreview.vue
@@ -35,7 +35,7 @@
             {{ service.description }}
           </p>
 
-          <router-link
+          <!-- <router-link
             :to="`/services/${service.slug}`"
             class="inline-flex items-center text-primary-600 font-medium hover:text-primary-700"
           >
@@ -52,16 +52,16 @@
                 clip-rule="evenodd"
               />
             </svg>
-          </router-link>
+          </router-link> -->
         </div>
       </div>
 
       <!-- Кнопка "Все услуги" -->
-      <div class="text-center mt-12">
+      <!-- <div class="text-center mt-12">
         <router-link to="/services" class="btn btn-primary hover:text-white">
           Все услуги
         </router-link>
-      </div>
+      </div> -->
     </div>
   </section>
 </template>

--- a/src/pages/CasesPage.vue
+++ b/src/pages/CasesPage.vue
@@ -281,7 +281,7 @@
               </div>
 
               <!-- CTA Button -->
-              <router-link
+              <!-- <router-link
                 :to="`/cases/${caseItem.slug}`"
                 class="inline-flex items-center text-primary-600 font-medium hover:text-primary-700 mt-auto"
               >
@@ -298,7 +298,7 @@
                     clip-rule="evenodd"
                   />
                 </svg>
-              </router-link>
+              </router-link> -->
             </div>
           </div>
         </div>

--- a/src/pages/ContactsPage.vue
+++ b/src/pages/ContactsPage.vue
@@ -3,7 +3,7 @@
     <!-- Шапка страницы -->
     <section class="bg-primary-700 text-white py-12 md:py-20">
       <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="max-w-3xl">
+        <div class="max-w-3xl text-left">
           <h1 class="text-3xl md:text-4xl font-bold mb-4">Свяжитесь с нами</h1>
           <p class="text-xl opacity-90">
             Оставьте заявку для консультации или напишите нам — ответим в


### PR DESCRIPTION
This pull request includes changes to temporarily disable certain navigation links and buttons across the application and a minor style adjustment on the Contacts page. The most important changes are grouped into navigation updates and style adjustments.

### Navigation Updates:

* **Disabled Navigation Links in `AppFooter` and `AppHeader`:** Commented out the "Услуги," "Блог," and "Тарифы" menu items in both `src/components/common/AppFooter.vue` and `src/components/common/AppHeader.vue`. These links are now hidden from the navigation menus. [[1]](diffhunk://#diff-add55efea7c253b79fe8b3075ebb7709055202c7e65be63f3f066e2e6c75833cL174-R179) [[2]](diffhunk://#diff-1820f6ff693d4776d847d9be3a577ccc1e6933e7a557608a4f351c2fb5b4ea90L115-R120)
* **Disabled "Подробнее" Buttons in `CasesPreview` and `CasesPage`:** Commented out the "Подробнее" (`router-link`) buttons for navigating to individual case pages in `src/components/home/CasesPreview.vue` and `src/pages/CasesPage.vue`. [[1]](diffhunk://#diff-c94d3df81e6fa94ae8e717919a780dc35a20f07331be2a3df58258160152afabL83-R83) [[2]](diffhunk://#diff-c94d3df81e6fa94ae8e717919a780dc35a20f07331be2a3df58258160152afabL100-R100) [[3]](diffhunk://#diff-75b1bc0cc807c9589e59ddbe88eb3659c8e2283e5ad571eba5eaf5da0856480aL284-R284) [[4]](diffhunk://#diff-75b1bc0cc807c9589e59ddbe88eb3659c8e2283e5ad571eba5eaf5da0856480aL301-R301)
* **Disabled "Все услуги" Button in `ServicesPreview`:** Commented out the "Все услуги" button and individual service navigation buttons in `src/components/home/ServicesPreview.vue`. [[1]](diffhunk://#diff-ed0fcd79e852e3961867d4964db42d1c7904995656a8a9b6a65c683b42a78c54L38-R38) [[2]](diffhunk://#diff-ed0fcd79e852e3961867d4964db42d1c7904995656a8a9b6a65c683b42a78c54L55-R64)

### Style Adjustment:

* **Contact Page Header Alignment:** Added a `text-left` class to the header container in `src/pages/ContactsPage.vue` to ensure the text aligns to the left.